### PR TITLE
Plotting script correction of a variable name to a lower-case

### DIFF
--- a/ush/Python/plot_allvars.py
+++ b/ush/Python/plot_allvars.py
@@ -353,7 +353,7 @@ for fhr in fhours:
   cin = data1.select(name='Convective inhibition',typeOfLevel='surface')[0].values
 
 # 500 mb height, wind, vorticity
-  z500 = data1.select(name='Geopotential Height',level=500)[0].values * 0.1
+  z500 = data1.select(name='Geopotential height',level=500)[0].values * 0.1
   z500 = ndimage.filters.gaussian_filter(z500, 6.89)
   vort500 = data1.select(name='Absolute vorticity',level=500)[0].values * 100000
   vort500 = ndimage.filters.gaussian_filter(vort500,1.7225)

--- a/ush/Python/plot_allvars_diff.py
+++ b/ush/Python/plot_allvars_diff.py
@@ -383,9 +383,9 @@ for fhr in fhours:
   cin_diff = cin_2 - cin_1
 
 # 500 mb height, wind, vorticity
-  z500_1 = data1.select(name='Geopotential Height',level=500)[0].values * 0.1
+  z500_1 = data1.select(name='Geopotential height',level=500)[0].values * 0.1
   z500_1 = ndimage.filters.gaussian_filter(z500_1, 6.89)
-  z500_2 = data2.select(name='Geopotential Height',level=500)[0].values * 0.1
+  z500_2 = data2.select(name='Geopotential height',level=500)[0].values * 0.1
   z500_2 = ndimage.filters.gaussian_filter(z500_2, 6.89)
   z500_diff = z500_2 - z500_1
   vort500_1 = data1.select(name='Absolute vorticity',level=500)[0].values * 100000


### PR DESCRIPTION
NB: Similar to a [PR-468](https://github.com/ufs-community/ufs-srweather-app/pull/468) to a develop branch

## DESCRIPTION OF CHANGES: 
Running plotting script throws an error when new miniconda/python are used.
The fix is to use the lower-case name of the one of the plotted variables.

The fix originally found and applied by @EdwardSnyder-NOAA , tested by 
@BruceKropp-Raytheon . The fix was limited to applying it using "sed" at the time of plotting.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
@BruceKropp-Raytheon was performing testing

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:



A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [x] bug
- [ ] enhancement
- [ ] documentation
- [x] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
@EdwardSnyder-NOAA @BruceKropp-Raytheon @gspetro-NOAA 

