### PR TITLE
[gaea-c5] Update Jenkinsfile, srw_build, srw_ftest, srw_test, and wrapper_srw_ftest to adjust for new gaea label

### DIFF
--- a/.cicd/Jenkinsfile
+++ b/.cicd/Jenkinsfile
@@ -10,10 +10,10 @@ pipeline {
     parameters {
         // Allow job runner to filter based on platform
         // Use the line below to enable all PW clusters
-        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'cheyenne', 'gaeac5', 'hera', 'jet', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2eus1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
+        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'cheyenne', 'gaea', 'hera', 'jet', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2eus1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
         // Use the line below to enable the PW AWS cluster
-        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'cheyenne', 'gaeac5', 'hera', 'jet', 'orion', 'hercules', 'pclusternoaav2use1'], description: 'Specify the platform(s) to use')
-        choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac5', 'hera', 'jet', 'orion', 'hercules'], description: 'Specify the platform(s) to use')
+        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'cheyenne', 'gaea', 'hera', 'jet', 'orion', 'hercules', 'pclusternoaav2use1'], description: 'Specify the platform(s) to use')
+        choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaea', 'hera', 'jet', 'orion', 'hercules'], description: 'Specify the platform(s) to use')
         // Allow job runner to filter based on compiler
         choice(name: 'SRW_COMPILER_FILTER', choices: ['all', 'gnu', 'intel'], description: 'Specify the compiler(s) to use to build')
         booleanParam name: 'SRW_WE2E_COMPREHENSIVE_TESTS', defaultValue: false, description: 'Whether to execute the comprehensive end-to-end tests'
@@ -86,7 +86,7 @@ pipeline {
                 axes {
                     axis {
                         name 'SRW_PLATFORM'
-                        values 'derecho', 'gaeac5', 'hera', 'jet', 'orion', 'hercules' //, 'pclusternoaav2use1', 'azclusternoaav2eus1', 'gclusternoaav2usc1'
+                        values 'derecho', 'gaea', 'hera', 'jet', 'orion', 'hercules' //, 'pclusternoaav2use1', 'azclusternoaav2eus1', 'gclusternoaav2usc1'
                     }
 
                     axis {
@@ -100,7 +100,7 @@ pipeline {
                     exclude {
                             axis {
                             name 'SRW_PLATFORM'
-                            values 'derecho', 'gaeac5', 'jet', 'orion', 'hercules' //, 'pclusternoaav2use1' , 'azclusternoaav2eus1', 'gclusternoaav2usc1'
+                            values 'derecho', 'gaea', 'jet', 'orion', 'hercules' //, 'pclusternoaav2use1' , 'azclusternoaav2eus1', 'gclusternoaav2usc1'
                         }
 
                         axis {

--- a/.cicd/scripts/srw_build.sh
+++ b/.cicd/scripts/srw_build.sh
@@ -20,8 +20,6 @@ fi
 declare platform
 if [[ "${SRW_PLATFORM}" =~ ^(az|g|p)clusternoaa ]]; then
     platform='noaacloud'
-elif [[ "${SRW_PLATFORM}" = gaeac5 ]]; then
-    platform='gaea'
 else
     platform="${SRW_PLATFORM}"
 fi

--- a/.cicd/scripts/srw_ftest.sh
+++ b/.cicd/scripts/srw_ftest.sh
@@ -39,8 +39,6 @@ fi
 declare platform
 if [[ "${SRW_PLATFORM}" =~ ^(az|g|p)clusternoaa ]]; then
     platform='noaacloud'
-elif [[ "${SRW_PLATFORM}" = gaeac5 ]]; then
-    platform='gaea'
 else
     platform="${SRW_PLATFORM}"
 fi

--- a/.cicd/scripts/srw_test.sh
+++ b/.cicd/scripts/srw_test.sh
@@ -21,8 +21,6 @@ fi
 declare platform
 if [[ "${SRW_PLATFORM}" =~ ^(az|g|p)clusternoaa ]]; then
     platform='noaacloud'
-elif [[ "${SRW_PLATFORM}" = gaeac5 ]]; then
-    platform='gaea'
 else
     platform="${SRW_PLATFORM}"
 fi

--- a/.cicd/scripts/wrapper_srw_ftest.sh
+++ b/.cicd/scripts/wrapper_srw_ftest.sh
@@ -23,7 +23,7 @@ else
 fi
 
 # Customize wrapper scripts
-if [[ "${SRW_PLATFORM}" == gaeac5 ]]; then
+if [[ "${SRW_PLATFORM}" == gaea ]]; then
     sed -i '15i #SBATCH --clusters=c5' ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
     sed -i 's|qos=batch|qos=normal|g' ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
 fi


### PR DESCRIPTION
Removing `gaeac5` logic from `srw_build`, `srw_ftest`, `srw_test`, and `wrapper_srw_ftest` Jenkins scripts.  Replacing `gaeac5` label with new `gaea` label in `Jenkinsfile`.