### PR TITLE
Safety and simplification updates for devclean.sh

### DIFF
--- a/devclean.sh
+++ b/devclean.sh
@@ -103,7 +103,6 @@ if [ ${REMOVE_SUB_MODULES} == true ]; then
   if [ "${VERBOSE}" = true ] ; then
     printf '%s\n' "Note: Need to check out submodules again for any subsequent builds, " \
       " by running ${SRW_DIR}/manage_externals/checkout_externals "
-#    removal_list+=( "${removal_list[@]}" "${submodules[@]}" )
   fi
 fi
 
@@ -111,8 +110,15 @@ fi
 if [ "${REMOVE_CONDA}" = true ] ; then
   # Do not read "conda_loc" file to determine location of conda install; if the user has changed it to a different location
   # they likely do not want to remove it!
-  removal_list+=("${SRW_DIR}/conda_loc")
-  removal_list+=("${SRW_DIR}/conda")
+  conda_location=$(<${SRW_DIR}/conda_loc)
+  echo "conda_location=$conda_location"
+  if [ "${conda_location}" == "${SRW_DIR}/conda" ]; then
+    removal_list+=("${SRW_DIR}/conda_loc")
+    removal_list+=("${SRW_DIR}/conda")
+  else
+    echo "WARNING: location of conda build in ${SRW_DIR}/conda_loc is not the default location!"
+    echo "Will not attempt to remove conda!"
+  fi
 fi
 
 while [ ${REMOVE} == false ]; do
@@ -122,7 +128,7 @@ while [ ${REMOVE} == false ]; do
      echo "$i"
   done
   echo ""
-  read -p "Confirm that you want to delete these files/directories! (Yes/No):" choice
+  read -p "Confirm that you want to delete these files/directories! (Yes/No): " choice
   case ${choice} in
     Yes ) REMOVE=true ;;
     [Nn]* ) echo "User chose not to delete, exiting..."; exit ;;

--- a/devclean.sh
+++ b/devclean.sh
@@ -4,30 +4,27 @@
 usage () {
 cat << EOF_USAGE
 
-Clean the UFS-SRW Application build, when located under the main SRW tree
+Clean the UFS-SRW Application build. If no arguments are provided, will only delete standard build
+artifacts; to delete submodules and/or conda, see optional arguments below.
+
+NOTE: If user included custom directories at build time, those directories must be deleted manually
+
 Usage: $0 [OPTIONS] ...
 
 OPTIONS
   -h, --help
       show this help guide
-  -a, --all
-      removes "bin", "build" directories, and other build artifacts
-  --bin-dir=BIN_DIR
-      binaries directory name under the SRW tree ("exec" default)
-  --build-dir=BUILD_DIR
-      build directory name under the SRW tree ("build" default)
-  --clean
-      removes "bin", "build" directories, and other build artifacts (same as "-a", "--all")
-  --conda-dir=CONDA_DIR
-      directory name under the SRW tree where conda is installed ("conda" default)
-  --remove
-      remove the BUILD_DIR only ("build" default), keep the BIN_DIR ("exec" default), "lib" and other build artifacts intact
-  --remove-conda
-      removes CONDA_DIR ("conda" default) directory and conda_loc file from the SRW tree
-  --sub-modules
-      remove sub-module directories. They need to be checked out again by sourcing "\${SRW_DIR}/manage_externals/checkout_externals" before attempting subsequent builds
+  --force
+      removes files and directories without confirmation. Use with caution!
   -v, --verbose
       provide more verbose output
+
+  -a, --all
+      removes all build artifacts, including conda and submodules
+  --conda
+      removes "conda" directory and conda_loc file in SRW
+  --sub-modules
+      remove sub-module directories. They will need to be checked out again by running "\${SRW_DIR}/manage_externals/checkout_externals" before attempting subsequent builds
 
 EOF_USAGE
 }
@@ -37,19 +34,10 @@ settings () {
 cat << EOF_SETTINGS
 Settings:
 
-  SRW_DIR=${SRW_DIR}
-  BUILD_DIR=${BUILD_DIR}
-  BIN_DIR=${BIN_DIR}
-  CONDA_DIR=${CONDA_DIR}
-  REMOVE=${REMOVE}
-  REMOVE_CONDA=${REMOVE_CONDA}
+  FORCE=${REMOVE}
   VERBOSE=${VERBOSE}
-
-Default cleaning options: (if no arguments provided, then nothing is cleaned)
- REMOVE=${REMOVE}
- CLEAN=${CLEAN}
- REMOVE_CONDA=${REMOVE_CONDA}
- REMOVE_SUB_MODULES=${REMOVE_SUB_MODULES}
+  REMOVE_SUB_MODULES=${REMOVE_SUB_MODULES}
+  REMOVE_CONDA=${REMOVE_CONDA}  
 
 EOF_SETTINGS
 }
@@ -63,44 +51,24 @@ usage_error () {
 
 # default settings
 SRW_DIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
-BUILD_DIR=${BUILD_DIR:-"build"}
-BIN_DIR=${BIN_DIR:-"exec"}
-CONDA_DIR=${CONDA_DIR:-"conda"}
-REMOVE=false
-REMOVE_CONDA=false
 VERBOSE=false
 
 # default clean options
 REMOVE=false
-CLEAN=false
-REMOVE_SUB_MODULES=false #changes to true if '--sub-modules' option is provided
+REMOVE_CONDA=false
+REMOVE_SUB_MODULES=false
 
-# process requires arguments
-if [[ ("$1" == "--help") || ("$1" == "-h") ]]; then
-  usage
-  exit 0
-fi
-
-# process optional arguments
+# process arguments
 while :; do
   case $1 in
     --help|-h) usage; exit 0 ;;
-    --all|-a) ALL_CLEAN=true ;;
-    --build-dir=?*) BUILD_DIR=${1#*=} ;;
-    --build-dir|--build-dir=) usage_error "$1 requires argument." ;;
-    --bin-dir=?*) BIN_DIR=${1#*=} ;;
-    --bin-dir|--bin-dir=) usage_error "$1 requires argument." ;;
-    --clean) CLEAN=true ;;
-    --conda-dir=?*) CONDA_DIR=${1#*=} ;;
-    --conda-dir|--conda-dir=) usage_error "$1 requires argument." ;;
-    --remove) REMOVE=true ;;
-    --remove=?*|--remove=) usage_error "$1 argument ignored." ;;
-    --remove-conda) REMOVE_CONDA=true ;;
+    --all|-a) REMOVE_CONDA=true; REMOVE_SUB_MODULES=true ;;
+    --conda) REMOVE_CONDA=true ;;
+    --force) REMOVE=true ;;
+    --force=?*|--force=) usage_error "$1 argument ignored." ;;
     --sub-modules) REMOVE_SUB_MODULES=true ;;
+    --sub-modules=?*|--sub-modules=) usage_error "$1 argument ignored." ;;
     --verbose|-v) VERBOSE=true ;;
-    --verbose=?*|--verbose=) usage_error "$1 argument ignored." ;;
-    # targets
-    default) ALL_CLEAN=false ;;
     # unknown
     -?*|?*) usage_error "Unknown option $1" ;;
     *) break ;;
@@ -108,63 +76,74 @@ while :; do
   shift
 done
 
-# Make sure to be in the SRW main directory before any removing or cleaning
-cd ${SRW_DIR}
-
-# choose defaults to clean
-if [ "${ALL_CLEAN}" = true ]; then
-  CLEAN=true
-fi
 
 # print settings
 if [ "${VERBOSE}" = true ] ; then
   settings
 fi
 
-# clean if build directory already exists 
-if [ "${REMOVE}" = true ] && [ "${CLEAN}" = false ] ; then
-  printf '%s\n' "Remove the \"build\" directory only, BUILD_DIR = $BUILD_DIR "
-  [[ -d ${BUILD_DIR} ]] && rm -rf ${BUILD_DIR} && printf '%s\n' "rm -rf ${BUILD_DIR}"
-elif [ "${CLEAN}" = true ]; then
-  printf '%s\n' "Remove build directory, binaries directory, and other build artifacts "
-  printf '%s\n' " from the ${SRW_DIR} "
+# Populate "removal_list" as an array of files/directories to remove
 
-  directories=( \
-    "${BUILD_DIR}" \
-    "${BIN_DIR}" \
-    "$share" \
-    "$include" \
-    "$lib" \
-    "$lib64" \
+# Standard build artifacts
+  removal_list=( \
+    "${SRW_DIR}/build" \
+    "${SRW_DIR}/exec" \
+    "${SRW_DIR}/share" \
+    "${SRW_DIR}/include" \
+    "${SRW_DIR}/lib" \
+    "${SRW_DIR}/lib64" \
   )
-  if [ ${#directories[@]} -ge 1 ]; then
-    for dir in ${directories[@]}; do 
-     [[ -d "${dir}" ]] && ( rm -rf ${dir} &&  printf '%s\n' "Removing ${dir} directory") 
-    done
-  echo " "
-  fi
-fi
-# Clean all the submodules if requested. Note: Need to check out them again before attempting subsequent builds, by sourcing ${SRW_DIR}/manage_externals/checkout_externals
+
+# Clean all the submodules if requested.
 if [ ${REMOVE_SUB_MODULES} == true ]; then
-  printf '%s\n' "Removing submodules ..."
   declare -a submodules='()'
-  submodules=(./sorc/*) 
-# echo " submodules are: ${submodules[@]} (total of ${#submodules[@]}) "
-  if [ ${#submodules[@]} -ge 1 ]; then
-    for sub in ${submodules[@]}; do [[ -d "${sub}" ]] && ( rm -rf ${sub} && printf '%s\n' "Removing ${sub} directory" ); done
+  submodules=(./sorc/*)
+  # Only add directories to make sure we don't delete CMakeLists.txt
+  for sub in ${submodules[@]}; do [[ -d "${sub}" ]] && removal_list+=( "${sub}" ); done
+  if [ "${VERBOSE}" = true ] ; then
+    printf '%s\n' "Note: Need to check out submodules again for any subsequent builds, " \
+      " by running ${SRW_DIR}/manage_externals/checkout_externals "
+#    removal_list+=( "${removal_list[@]}" "${submodules[@]}" )
   fi
-  printf '%s\n' "Note: Need to check out submodules again for any subsequent builds, " \
-    " by sourcing ${SRW_DIR}/manage_externals/checkout_externals "
 fi
-#
 
 # Clean conda if requested
 if [ "${REMOVE_CONDA}" = true ] ; then
-  [[ -d "${CONDA_DIR}" ]] &&  rm -rf ${CONDA_DIR} && printf '%s\n' "Removing conda installation directory, ${CONDA_DIR}, from the SRW directory tree"
-  [[ -f "conda_loc" ]] &&  rm -f "conda_loc" && printf '%s\n' "Removing conda_loc file"
+  # Do not read "conda_loc" file to determine location of conda install; if the user has changed it to a different location
+  # they likely do not want to remove it!
+  removal_list+=("${SRW_DIR}/conda_loc")
+  removal_list+=("${SRW_DIR}/conda")
 fi
 
-echo " "
-echo "All the requested cleaning tasks have been completed"
-echo " "
+while [ ${REMOVE} == false ]; do
+  # Make user confirm deletion of directories unless '--force' option was provided
+  printf "The following files/directories will be deleted:\n\n"
+  for i in "${removal_list[@]}"; do
+     echo "$i"
+  done
+  echo ""
+  read -p "Confirm that you want to delete these files/directories! (Yes/No):" choice
+  case ${choice} in
+    Yes ) REMOVE=true ;;
+    [Nn]* ) echo "User chose not to delete, exiting..."; exit ;;
+    * ) printf "Invalid option selected.\n" ;;
+  esac
+done
+
+if [ ${REMOVE} == true ]; then
+  for dir in ${removal_list[@]}; do
+    echo "Removing ${dir}"
+    if [ "${VERBOSE}" = true ] ; then 
+      rm -rfv ${dir}
+    else
+      rm -rf ${dir}
+    fi
+  done
+  echo " "
+  echo "All the requested cleaning tasks have been completed"
+  echo " "
+fi
+
+
+exit 0
 

--- a/devclean.sh
+++ b/devclean.sh
@@ -12,22 +12,25 @@ Usage: $0 [OPTIONS] ...
 
 OPTIONS
   -h, --help
-      show this help guide
+      Show this help guide
   --force
-      removes files and directories without confirmation. Use with caution!
+      Removes files and directories without confirmation. Use with caution!
   -v, --verbose
-      provide more verbose output
+      Provide more verbose output
 
   -a, --all
-      removes all build artifacts, conda and submodules (equivalent to \`-b -c -s\`)
+      Removes all build artifacts, conda and submodules (equivalent to \`-b -c -s\`)
   -b, --build
-      removes build directories and artifacts:  build/ exec/ share/ include/ lib/ lib64/
+      Removes build directories and artifacts:  build/ exec/ share/ include/ lib/ lib64/
   -c, --conda
-      removes "conda" directory and conda_loc file in SRW
+      Removes "conda" directory and conda_loc file in SRW
   -s, --sub-modules
-      remove sub-module directories. They will need to be checked out again by running
+      Remove sub-module directories. They will need to be checked out again by running
       "./manage_externals/checkout_externals" before attempting subsequent builds
 
+  --container
+      For cleaning builds within the SRW Singularity container, will remove the "container-bin"
+      directory rather than "exec". Has no effect if \`-b\` is not specified.
 EOF_USAGE
 }
 
@@ -60,6 +63,7 @@ REMOVE=false
 REMOVE_BUILD=false
 REMOVE_CONDA=false
 REMOVE_SUB_MODULES=false
+CONTAINER=false
 
 # process arguments
 while :; do
@@ -68,6 +72,7 @@ while :; do
     --all|-a) REMOVE_BUILD=true; REMOVE_CONDA=true; REMOVE_SUB_MODULES=true ;;
     --build|-b) REMOVE_BUILD=true ;;
     --conda|-c) REMOVE_CONDA=true ;;
+    --container) CONTAINER=true ;;
     --force) REMOVE=true ;;
     --force=?*|--force=) usage_error "$1 argument ignored." ;;
     --sub-modules|-s) REMOVE_SUB_MODULES=true ;;
@@ -92,12 +97,16 @@ fi
 if [ ${REMOVE_BUILD} == true ]; then
   removal_list=( \
     "${SRW_DIR}/build" \
-    "${SRW_DIR}/exec" \
     "${SRW_DIR}/share" \
     "${SRW_DIR}/include" \
     "${SRW_DIR}/lib" \
     "${SRW_DIR}/lib64" \
   )
+  if [ ${CONTAINER} == true ]; then
+    removal_list+=("${SRW_DIR}/container-bin")
+  else
+    removal_list+=("${SRW_DIR}/exec")
+  fi
 fi
 
 # Clean all the submodules if requested.

--- a/devclean.sh
+++ b/devclean.sh
@@ -117,7 +117,9 @@ if [ "${REMOVE_CONDA}" = true ] ; then
   # Do not read "conda_loc" file to determine location of conda install; if the user has changed it to a different location
   # they likely do not want to remove it!
   conda_location=$(<${SRW_DIR}/conda_loc)
-  echo "conda_location=$conda_location"
+  if [ "${VERBOSE}" = true ] ; then
+    echo "conda_location=$conda_location"
+  fi
   if [ "${conda_location}" == "${SRW_DIR}/conda" ]; then
     removal_list+=("${SRW_DIR}/conda_loc")
     removal_list+=("${SRW_DIR}/conda")

--- a/devclean.sh
+++ b/devclean.sh
@@ -13,24 +13,20 @@ Usage: $0 [OPTIONS] ...
 OPTIONS
   -h, --help
       Show this help guide
-  --force
-      Removes files and directories without confirmation. Use with caution!
+  -a, --all
+      Remove all build artifacts, conda and submodules (equivalent to \`-b -c -s\`)
+  -b, --build
+      Remove build directories and artifacts:  build/ exec/ share/ include/ lib/ lib64/
+  -c, --conda
+      Remove "conda" directory and conda_loc file in SRW main directory
+  --container
+      For cleaning builds within the SRW containers, will remove the "container-bin"
+      directory rather than "exec". Has no effect if \`-b\` is not specified.
+  -s, -sub-modules
+      Remove sub-module directories. They need to be checked out again by sourcing "\${SRW_DIR}/manage_externals/checkout_externals" before attempting subsequent builds
   -v, --verbose
       Provide more verbose output
-
-  -a, --all
-      Removes all build artifacts, conda and submodules (equivalent to \`-b -c -s\`)
-  -b, --build
-      Removes build directories and artifacts:  build/ exec/ share/ include/ lib/ lib64/
-  -c, --conda
-      Removes "conda" directory and conda_loc file in SRW
-  -s, --sub-modules
-      Remove sub-module directories. They will need to be checked out again by running
-      "./manage_externals/checkout_externals" before attempting subsequent builds
-
-  --container
-      For cleaning builds within the SRW Singularity container, will remove the "container-bin"
-      directory rather than "exec". Has no effect if \`-b\` is not specified.
+      
 EOF_USAGE
 }
 


### PR DESCRIPTION
These are the changes I am proposing for devclean.sh to make the script safe to use. The new behavior is:

 - Will only delete the build artifacts at their default locations. If users built in custom paths they need to delete them manually
 - Before deleting anything, puts the proposed deletions in a list and prompts user to confirm the deletion of the directories on screen
   - Does include a `--force` option for the bold, but that will be on them.
 - User should specify what they want to be deleted with optional flags; if no flags are specified then nothing gets deleted.